### PR TITLE
avoid CompUnitRepo::Local::File gobbling block

### DIFF
--- a/lib/Find/Bundled.pm6
+++ b/lib/Find/Bundled.pm6
@@ -9,7 +9,7 @@ method find(Str $lib, Str $base, :$keep-filename, :$return-original, :$throw) {
     for @*INC -> $_ is copy {
         $_ = CompUnitRepo.new($_);
         my $base = $b;
-        if $_ ~~ CompUnitRepo::Local::File {
+        if ($_ ~~ CompUnitRepo::Local::File) {
             # CUR::Local::File has screwed up .files semantics
             $base = $_.IO ~ '/' ~ $base;
         }


### PR DESCRIPTION
This error was preventing IO::Socket::SSL from installing for me on the latest rakudo/nqp/MoarVM:

<pre>===SORRY!===
Function 'CompUnitRepo::Local::File' needs parens to avoid gobbling block
    1 unit class Find::Bundled;
at /home/leedo/src/panda/.panda-work/1448836158_2/lib/Find/Bundled.pm6:15
------>         }⏏&lt;EOL&gt;
Missing block (apparently claimed by 'CompUnitRepo::Local::File')
at /home/leedo/src/panda/.panda-work/1448836158_2/lib/Find/Bundled.pm6:16
------>         }⏏&lt;EOL&gt;</pre>


<pre>This is rakudo version 2015.11-281-gdbfb5e2 built on MoarVM version 2015.11-21-g469ba64 implementing Perl v6.b</pre>
