### PR TITLE
CompUnit name changes for latest rakudo

### DIFF
--- a/lib/Find/Bundled.pm6
+++ b/lib/Find/Bundled.pm6
@@ -7,9 +7,9 @@ method find(Str $lib, Str $base, :$keep-filename, :$return-original, :$throw) {
         $b = $base~"/$lib";
     }
     for @*INC -> $_ is copy {
-        $_ = CompUnitRepo.new($_);
+        $_ = CompUnit::Repository.new($_);
         my $base = $b;
-        if ($_ ~~ CompUnitRepo::Local::File) {
+        if ($_ ~~ CompUnit::PrecompilationStore::File) {
             # CUR::Local::File has screwed up .files semantics
             $base = $_.IO ~ '/' ~ $base;
         }


### PR DESCRIPTION
 $ perl6 -v
This is rakudo version 2015.11-498-gb946a30 built on MoarVM version 2015.11-34-gc3eea17 implementing Perl v6.b.
